### PR TITLE
Get dir api

### DIFF
--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -195,7 +195,7 @@ func (c *Client) GetDir(owner, repo, branch, dir string) ([]*DirResponse, *Respo
 		return nil, nil, err
 	}
 	dir = pathEscapeSegments(strings.TrimPrefix(dir, "/"))
-	data, resp, err := c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/git/dir?path=%s&&branch=%s", owner, repo, dir, url.QueryEscape(branch)), jsonHeader, nil)
+	data, resp, err := c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/git/dir?path=%s&branch=%s", owner, repo, dir, url.QueryEscape(branch)), jsonHeader, nil)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // FileOptions options for all file APIs
@@ -95,14 +96,16 @@ type ContentsResponse struct {
 }
 
 type DirResponse struct {
-	Path      string `json:"path"`
-	Mode      string `json:"mode"`
-	Type      string `json:"type"`
-	Size      int64  `json:"size"`
-	SHA       string `json:"sha"`
-	URL       string `json:"url"`
-	CommitMsg string `json:"commit_msg"`
-	IsLfs     bool   `json:"is_lfs"`
+	Name          string    `json:"name"`
+	Path          string    `json:"path"`
+	Mode          string    `json:"mode"`
+	Type          string    `json:"type"`
+	Size          int64     `json:"size"`
+	SHA           string    `json:"sha"`
+	URL           string    `json:"url"`
+	CommitMsg     string    `json:"commit_msg"`
+	CommitterDate time.Time `json:"committer_date"`
+	IsLfs         bool      `json:"is_lfs"`
 }
 
 // FileCommitResponse contains information generated from a Git commit for a repo's file.


### PR DESCRIPTION
create a GetDir api to get basic file infos under a given directory.

branch and root dir can be set, but they are optional. 

call example:

`http://localhost:3000/api/v1/repos/leida/testrepo/git/dir?path=httpbase&branch=main`